### PR TITLE
Scrobble to Last.fm/Libre.fm via Simple Last.FM Scrobbler

### DIFF
--- a/res/values-mdpi/arrays.xml
+++ b/res/values-mdpi/arrays.xml
@@ -44,5 +44,13 @@ limitations under the License.
         <item>mp31</item>
         <item>ogg2</item>
     </string-array>
+    <string-array name="scrobbler_apps">
+        <item>@string/scrobbler_lastfm_official</item>
+        <item>@string/scrobbler_simplefm</item>
+    </string-array>
+    <string-array name="scrobbler_apps_values">
+        <item>lastfm</item>
+        <item>simplefm</item>
+    </string-array>
     
 </resources>

--- a/res/values-mdpi/strings.xml
+++ b/res/values-mdpi/strings.xml
@@ -121,4 +121,9 @@ limitations under the License.
 	<string name="loading_recomended_radios">Loading recomended radios</string>
 	<string name="failed_recomended_radios">Loading recomended radios failed</string>
 	<string name="play">Play</string>
+	<string name="scrobbler_app">Scrobbling application</string>
+	<string name="scrobbler_lastfm_official">Last.FM Official scrobbler</string>
+	<string name="scrobbler_simplefm">Simple Last.FM Scrobbler</string>
+	<string name="scrobbling_enabled">Enable scrobbling?</string>
+	<string name="scrobbler_app_summary">Choose scrobbling application</string>
 </resources>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -43,10 +43,9 @@ limitations under the License.
 	<PreferenceCategory android:title="3rd Party Applications"
 		android:summary="Interaction with outside applications">
 
-		<CheckBoxPreference android:key="lastfm_scrobble"
-			android:defaultValue="false" 
-			android:title="Last.fm Scrobbling"
-			android:summary="Requires official last.fm client" />
+		<CheckBoxPreference android:defaultValue="false" 
+			android:key="scrobbling_enabled" android:title="@string/scrobbling_enabled"/>
+		<ListPreference android:key="scrobbler_app" android:dependency="scrobbling_enabled" android:entries="@array/scrobbler_apps" android:title="@string/scrobbler_app" android:entryValues="@array/scrobbler_apps_values" android:summary="@string/scrobbler_app_summary"></ListPreference>
 		
 	</PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
Added Simple Last.Fm Scrobbler to list of scrobbling applications.
Configuration settings to either enable/disable scrobbling
and select desired application.

Scrobbling to app is intent-based therefore if target application
is not available on the system there will be no error.
