### PR TITLE
Fixing scrobble to last.fm . Closes #21

### DIFF
--- a/src/com/teleca/jamendo/JamendoApplication.java
+++ b/src/com/teleca/jamendo/JamendoApplication.java
@@ -357,6 +357,21 @@ public class JamendoApplication extends Application {
 			}
 			
 		}
+
+		@Override
+		public void ScrobbleWhenPaused() {
+			if(mServicePlayerEngine != null){
+				mServicePlayerEngine.ScrobbleWhenPaused();
+			}
+			
+		}
+
+		@Override
+		public void SendScrobbleFromMusic() {
+			if(mServicePlayerEngine != null){
+				mServicePlayerEngine.SendScrobbleFromMusic();
+			}			
+		}
 		
 	}	
 

--- a/src/com/teleca/jamendo/activity/PlayerActivity.java
+++ b/src/com/teleca/jamendo/activity/PlayerActivity.java
@@ -444,6 +444,7 @@ public class PlayerActivity extends Activity {
 		@Override
 		public void onClick(View v) {
 			if(getPlayerEngine().isPlaying()){
+				getPlayerEngine().ScrobbleWhenPaused();
 				getPlayerEngine().pause();
 			} else {
 				getPlayerEngine().play();
@@ -598,6 +599,18 @@ public class PlayerActivity extends Activity {
 		@Override
 		public void onTrackStreamError() {
 			Toast.makeText(PlayerActivity.this, R.string.stream_error, Toast.LENGTH_LONG).show();
+		}
+
+		@Override
+		public void sendScrobblerMetaChanged(long time) {
+			// TODO Auto-generated method stub
+			
+		}
+
+		@Override
+		public void SendScrobbleWhenPaused() {
+			// TODO Auto-generated method stub
+			
 		}
 
 	};

--- a/src/com/teleca/jamendo/gestures/PlayerGestureNextCommand.java
+++ b/src/com/teleca/jamendo/gestures/PlayerGestureNextCommand.java
@@ -19,6 +19,8 @@ public class PlayerGestureNextCommand implements GestureCommand {
 	@Override
 	public void execute() {
 		Log.v(JamendoApplication.TAG, "PlayerGestureNextCommand");
+		if(!mPlayerEngine.isPlaying())
+			mPlayerEngine.SendScrobbleFromMusic();
 		mPlayerEngine.next();
 	}
 	

--- a/src/com/teleca/jamendo/gestures/PlayerGesturePlayCommand.java
+++ b/src/com/teleca/jamendo/gestures/PlayerGesturePlayCommand.java
@@ -17,6 +17,7 @@ public class PlayerGesturePlayCommand implements GestureCommand {
 	public void execute() {
 		Log.v(JamendoApplication.TAG, "PlayerGesturePlayCommand");
 		if (mPlayerEngine.isPlaying()) {
+			mPlayerEngine.ScrobbleWhenPaused();
 			mPlayerEngine.pause();
 		} else {
 			mPlayerEngine.play();

--- a/src/com/teleca/jamendo/gestures/PlayerGesturePrevCommand.java
+++ b/src/com/teleca/jamendo/gestures/PlayerGesturePrevCommand.java
@@ -16,6 +16,8 @@ public class PlayerGesturePrevCommand implements GestureCommand {
 	@Override
 	public void execute() {
 		Log.v(JamendoApplication.TAG, "PlayerGesturePrevCommand");
+		if(!mPlayerEngine.isPlaying())
+			mPlayerEngine.SendScrobbleFromMusic();
 		mPlayerEngine.prev();
 	}
 	

--- a/src/com/teleca/jamendo/media/PlayerEngine.java
+++ b/src/com/teleca/jamendo/media/PlayerEngine.java
@@ -112,4 +112,15 @@ public interface PlayerEngine {
 	 * @param miliseconds to rewind
 	 */
 	public void rewind(int time);
+	
+	/**
+	 * Send scrobbler to inform you that the music stopped
+	 * */	
+	public void ScrobbleWhenPaused();
+	
+	
+	/**
+	 * Send scrobbler with position from music actual
+	 * */	
+	public void SendScrobbleFromMusic();
 }

--- a/src/com/teleca/jamendo/media/PlayerEngineImpl.java
+++ b/src/com/teleca/jamendo/media/PlayerEngineImpl.java
@@ -123,6 +123,14 @@ public class PlayerEngineImpl implements PlayerEngine {
                     }
             }
     };
+    
+    /**
+     * 
+     * */
+    
+    private long timeActual = 0;
+    
+    private long variation = 0;
 
 	/**
 	 * Default constructor
@@ -161,6 +169,11 @@ public class PlayerEngineImpl implements PlayerEngine {
 			// check if we play, then pause
 			if(mCurrentMediaPlayer.isPlaying()){
 				mCurrentMediaPlayer.pause();
+				
+				//part of the music performed
+				variation = variation + System.currentTimeMillis() - timeActual;
+				
+				
 				if(mPlayerEngineListener != null)
 					mPlayerEngineListener.onTrackPause();
 				return;
@@ -205,6 +218,18 @@ public class PlayerEngineImpl implements PlayerEngine {
                     mHandler.removeCallbacks(mUpdateTimeTask);
                     mHandler.postDelayed(mUpdateTimeTask, 1000);
 					
+                    long time = mCurrentMediaPlayer.getCurrentPosition();
+                    
+                    // if the music is continuing
+                    if(time > 0)
+                    {
+                    	SendScrobbleFromMusic();
+                    }
+                    else{
+                    	// music is started
+                    	variation = 0;
+                    }
+                    timeActual = System.currentTimeMillis();
 					mCurrentMediaPlayer.start();
 				}
 			} else {
@@ -424,5 +449,21 @@ public class PlayerEngineImpl implements PlayerEngine {
 	@Override
 	public void rewind(int time) {
 		mCurrentMediaPlayer.seekTo( mCurrentMediaPlayer.getCurrentPosition()-time );
+	}
+
+	@Override
+	public void ScrobbleWhenPaused() {
+		mPlayerEngineListener.SendScrobbleWhenPaused();
+		
+	}
+
+	@Override
+	public void SendScrobbleFromMusic() {
+		long time = 0;
+		if(!mCurrentMediaPlayer.isPlaying())
+			time = variation;
+		else
+			time = System.currentTimeMillis() - timeActual + variation;
+		mPlayerEngineListener.sendScrobblerMetaChanged(mCurrentMediaPlayer.getCurrentPosition());		
 	}
 }

--- a/src/com/teleca/jamendo/media/PlayerEngineListener.java
+++ b/src/com/teleca/jamendo/media/PlayerEngineListener.java
@@ -16,7 +16,10 @@
 
 package com.teleca.jamendo.media;
 
+import android.preference.PreferenceManager;
+
 import com.teleca.jamendo.api.PlaylistEntry;
+import com.teleca.jamendo.service.PlayerService;
 
 
 /**
@@ -71,5 +74,18 @@ public interface PlayerEngineListener {
 	 * streaming
 	 */
 	public void onTrackStreamError();
+	
+	/**
+	 * Callback invoked when a scrobbler is started
+	 * */
+	
+	public void sendScrobblerMetaChanged(long time);
+	
+	/**
+	 * Callback invoked when a scrobbler is paused
+	 * 
+	 * @param time
+	 * */
+	public void SendScrobbleWhenPaused();
 
 }

--- a/src/com/teleca/jamendo/service/PlayerService.java
+++ b/src/com/teleca/jamendo/service/PlayerService.java
@@ -217,6 +217,12 @@ public class PlayerService extends Service{
 			if(mRemoteEngineListener != null){
 				mRemoteEngineListener.onTrackStop();
 			}
+			
+			// Scrobbling
+			boolean scrobblingEnabled = PreferenceManager.getDefaultSharedPreferences(PlayerService.this).getBoolean("scrobbling_enabled", false);
+			if (scrobblingEnabled) {
+				scrobblerPlaybackStop();
+			}
 		}
 
 		@Override
@@ -299,6 +305,16 @@ public class PlayerService extends Service{
 				// somehow the scrobbling app is not selected properly
 			}
 		}
+	}
+	
+	private void scrobblerPlaybackStop() {
+		String scrobblerApp = PreferenceManager.getDefaultSharedPreferences(PlayerService.this).getString("scrobbler_app", "");
+		assert(scrobblerApp.length() > 0);
+		
+		if (scrobblerApp.equalsIgnoreCase("lastfm")) {
+			Intent i = new Intent("fm.last.android.playbackpaused");
+			sendBroadcast(i);
+		}		
 	}
 
 	private void displayNotifcation(PlaylistEntry playlistEntry)

--- a/src/com/teleca/jamendo/util/OnSeekToListenerImp.java
+++ b/src/com/teleca/jamendo/util/OnSeekToListenerImp.java
@@ -77,6 +77,8 @@ public class OnSeekToListenerImp implements OnTouchListener {
 		if (event.getAction() == MotionEvent.ACTION_DOWN) {
 			startTime = System.currentTimeMillis();
 			mSeekTimer.start();
+			if(!mPlayerEngine.isPlaying())
+				mPlayerEngine.SendScrobbleFromMusic();
 			mPlayerEngine.pause();
 			mPlayerActivity.onStartSeekToProcess();
 			stepOfSeekTo = INIT_SEEK_TO_STEP;


### PR DESCRIPTION
Intens are sent warning if music has stopped or paused. When music is restarted, the point that it was stopped is sent, so scrobble should continue from this point.
