### PR TITLE
Equalizer on ICS/JB

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -159,7 +159,7 @@
 	</application>
 	<uses-permission android:name="android.permission.INTERNET"></uses-permission>
 	<uses-permission android:name="android.permission.ACCESS_WIFI_STATE"></uses-permission>
-	<uses-sdk android:minSdkVersion="4" android:targetSdkVersion="10"></uses-sdk>
+	<uses-sdk android:minSdkVersion="9" android:targetSdkVersion="10"></uses-sdk>
 	<uses-permission android:name="android.permission.READ_PHONE_STATE"></uses-permission>
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"></uses-permission>
 	<uses-permission android:name="android.permission.WAKE_LOCK"></uses-permission>

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -164,4 +164,5 @@
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"></uses-permission>
 	<uses-permission android:name="android.permission.WAKE_LOCK"></uses-permission>
 	<uses-permission android:name="android.permission.RECORD_AUDIO"></uses-permission>
+	<uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"></uses-permission>
 </manifest> 

--- a/res/layout-mdpi/equalizer.xml
+++ b/res/layout-mdpi/equalizer.xml
@@ -31,50 +31,6 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content" >
             
-            <RadioButton
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/normal" />
-            <RadioButton
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/classical" />
-            <RadioButton
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/dance" />
-            <RadioButton
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/flat" />
-            <RadioButton
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/folk" />
-            <RadioButton
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/heavy_metal" />
-            <RadioButton
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/hip_hop" />
-            <RadioButton
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/jazz" />
-            <RadioButton
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/pop" />
-            <RadioButton
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/rock" />
-			<RadioButton
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/custom" />
         </RadioGroup>
         
     </LinearLayout>

--- a/res/layout-mdpi/player.xml
+++ b/res/layout-mdpi/player.xml
@@ -211,7 +211,7 @@
 					android:layout_width="fill_parent" android:layout_height="wrap_content"
 					android:text="@string/add_to_playlist" android:layout_marginTop="10dip">
 				</Button>
-				<Button android:onClick="addOnClick" android:id="@+id/SliderEqualizer"
+				<Button android:onClick="equalizerOnClick" android:id="@+id/SliderEqualizer"
 					android:layout_width="fill_parent" android:layout_height="wrap_content"
 					android:text="@string/equalizer" android:layout_marginTop="10dip">
 				</Button>

--- a/res/values-mdpi/strings.xml
+++ b/res/values-mdpi/strings.xml
@@ -153,15 +153,5 @@ limitations under the License.
     <string name="preference_3rdparty_summary">Interaction with outside applications</string>
     <string name="close">Close</string>
     <string name="equalizer">Equalizer</string>
-    <string name="normal">Normal</string>
-    <string name="classical">Classical</string>
-    <string name="dance">Dance</string>
-    <string name="flat">Flat</string>
-    <string name="folk">Folk</string>
-    <string name="heavy_metal">Heavy Metal</string>
-    <string name="hip_hop">Hip Hop</string>
-    <string name="jazz">Jazz</string>
-    <string name="pop">Pop</string>
-    <string name="rock">Rock</string>
     <string name="custom">Custom</string>
 </resources>

--- a/src/com/teleca/jamendo/JamendoApplication.java
+++ b/src/com/teleca/jamendo/JamendoApplication.java
@@ -17,7 +17,6 @@
 package com.teleca.jamendo;
 
 import android.app.Application;
-import android.app.backup.RestoreObserver;
 import android.content.Intent;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
@@ -170,7 +169,13 @@ public class JamendoApplication extends Application {
 	public void updateEqualizerSettings(Equalizer.Settings settings) {
 		if (isEqualizerRunning()) {
 			// update running equalizer
-			mEqualizer.setProperties(settings);
+			try {
+				mEqualizer.setProperties(settings);
+			} catch (UnsupportedOperationException e) {
+				// applying equalizer settings after resuming
+				// from pause is not supported
+				// it may be ignored - the settings will remain unchanged
+			}
 		}
 		mEqualizerSettings = settings;
 		storeEqualizerSettings(mEqualizerSettings);

--- a/src/com/teleca/jamendo/JamendoApplication.java
+++ b/src/com/teleca/jamendo/JamendoApplication.java
@@ -23,6 +23,7 @@ import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.media.MediaPlayer;
 import android.media.audiofx.Equalizer;
+import android.media.audiofx.Equalizer.Settings;
 import android.preference.PreferenceManager;
 import com.teleca.jamendo.api.JamendoGet2Api;
 import com.teleca.jamendo.api.Playlist;
@@ -76,10 +77,15 @@ public class JamendoApplication extends Application {
 	private MediaPlayer mCurrentMedia;
 
 	/**
-	 * Equalizer settings
+	 * Equalizer instance for runtime manipulation
 	 */
 	private Equalizer mEqualizer;
 	
+	/**
+	 * Equalizer settings
+	 */
+	private Equalizer.Settings mEqualizerSettings;
+
 	/**
 	 * Intent player engine
 	 */
@@ -151,6 +157,31 @@ public class JamendoApplication extends Application {
 	
 	public Equalizer getMyEqualizer(){
 		return this.mEqualizer;
+	}
+
+	public Equalizer.Settings getEqualizerSettigns() {
+		return mEqualizerSettings;
+	}
+
+	public void updateEqualizerSettings(Equalizer.Settings settings) {
+		if (isEqualizerRunning()) {
+			// update running equalizer
+			mEqualizer.setProperties(settings);
+		}
+		mEqualizerSettings = settings;
+	}
+
+	private boolean isEqualizerRunning() {
+		if (mEqualizer != null) {
+			try {
+				mEqualizer.getProperties();
+				return true;
+			} catch (RuntimeException e) {
+				// this will be thrown if Equalizer instance is unusable
+				// it happens e.g. on ICS and JB
+			}
+		}
+		return false;
 	}
 
 	/**

--- a/src/com/teleca/jamendo/JamendoApplication.java
+++ b/src/com/teleca/jamendo/JamendoApplication.java
@@ -190,7 +190,7 @@ public class JamendoApplication extends Application {
 		}
 	}
 
-	private boolean isEqualizerRunning() {
+	public boolean isEqualizerRunning() {
 		if (mEqualizer != null) {
 			try {
 				mEqualizer.getProperties();
@@ -201,6 +201,21 @@ public class JamendoApplication extends Application {
 			}
 		}
 		return false;
+	}
+
+	/**
+	 * Equalizer preset to use when the next time an Equalizer
+	 * instance is created.
+	 * -1 is reserved for custom preset
+	 * -2 is reserved for no preset
+	 */
+	private short mEqualizerPreset = -2;
+	public void setEqualizerPreset(short preset) {
+		mEqualizerPreset = preset;
+	}
+
+	public short getEqualizerPreset() {
+		return mEqualizerPreset;
 	}
 
 	/**
@@ -435,6 +450,5 @@ public class JamendoApplication extends Application {
 			
 		}
 		
-	}	
-
+	}
 }

--- a/src/com/teleca/jamendo/JamendoApplication.java
+++ b/src/com/teleca/jamendo/JamendoApplication.java
@@ -17,6 +17,7 @@
 package com.teleca.jamendo;
 
 import android.app.Application;
+import android.app.backup.RestoreObserver;
 import android.content.Intent;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
@@ -25,6 +26,8 @@ import android.media.MediaPlayer;
 import android.media.audiofx.Equalizer;
 import android.media.audiofx.Equalizer.Settings;
 import android.preference.PreferenceManager;
+
+import com.teleca.jamendo.activity.EqualizerActivity;
 import com.teleca.jamendo.api.JamendoGet2Api;
 import com.teleca.jamendo.api.Playlist;
 import com.teleca.jamendo.api.Playlist.PlaylistPlaybackMode;
@@ -126,6 +129,7 @@ public class JamendoApplication extends Application {
 		instance = this;
 
 		mDownloadManager = new DownloadManagerImpl(this);
+		restoreEqualizerSettings();
 	}
 
 	/**
@@ -169,6 +173,21 @@ public class JamendoApplication extends Application {
 			mEqualizer.setProperties(settings);
 		}
 		mEqualizerSettings = settings;
+		storeEqualizerSettings(mEqualizerSettings);
+	}
+
+	private void storeEqualizerSettings(Settings equalizerSettings) {
+		PreferenceManager.getDefaultSharedPreferences(this).edit()
+			.putString(EqualizerActivity.PREFERENCE_EQUALIZER, equalizerSettings.toString())
+			.apply();
+	}
+
+	private void restoreEqualizerSettings() {
+		String settingsStr = PreferenceManager.getDefaultSharedPreferences(this)
+			.getString(EqualizerActivity.PREFERENCE_EQUALIZER, null);
+		if (settingsStr != null && settingsStr.length() > 0) {
+			mEqualizerSettings = new Settings(settingsStr);
+		}
 	}
 
 	private boolean isEqualizerRunning() {

--- a/src/com/teleca/jamendo/activity/EqualizerActivity.java
+++ b/src/com/teleca/jamendo/activity/EqualizerActivity.java
@@ -39,6 +39,9 @@ import android.widget.RadioGroup.OnCheckedChangeListener;
  *
  */
 public class EqualizerActivity extends Activity{
+
+	public static final String PREFERENCE_EQUALIZER = "equalizer";
+
     private Equalizer mEqualizer;
     private RadioGroup mRadioGroup;
     private Activity mActivity = this;

--- a/src/com/teleca/jamendo/activity/EqualizerActivity.java
+++ b/src/com/teleca/jamendo/activity/EqualizerActivity.java
@@ -68,23 +68,25 @@ public class EqualizerActivity extends Activity{
         final Equalizer equalizer = new Equalizer(0, 0);
         Log.i(JamendoApplication.TAG, "setupEqualizerFxAndUI " + equalizer.getNumberOfPresets());
         Settings settings = JamendoApplication.getInstance().getEqualizerSettigns();
-    	// radio button that custom the equalization
-    	RadioButton custom = (RadioButton) this.mRadioGroup.getChildAt(this.mRadioGroup.getChildCount() - 1);
+
     	// Association between radio button and prest equalization 
         final SparseArray<Short> group = new SparseArray<Short>();
     	
-        // The last child of radioGroup will be the custom, so it doesn't have an associated preset
-        int radios = this.mRadioGroup.getChildCount() - 2;
-    	
         for (int i = equalizer.getNumberOfPresets() - 1; i >= 0; i--) {
-            RadioButton button = (RadioButton) this.mRadioGroup.getChildAt(radios);
+            RadioButton button = new RadioButton(this);
+            button.setText(equalizer.getPresetName((short) i));
+            mRadioGroup.addView(button);
             group.put(button.getId(), (short) i);
             if (settings != null && settings.curPreset == i) {
                 button.setChecked(true);
             }
-            radios--;
         }
-        Log.i(JamendoApplication.TAG, "settings: " + settings);
+
+        // radio button that custom the equalization
+        RadioButton custom = new RadioButton(this);
+        custom.setText(R.string.custom);
+        mRadioGroup.addView(custom);
+
         if (settings == null || settings.curPreset == -1) {
             mRadioGroup.check(custom.getId());
         }

--- a/src/com/teleca/jamendo/media/PlayerEngineImpl.java
+++ b/src/com/teleca/jamendo/media/PlayerEngineImpl.java
@@ -210,17 +210,27 @@ public class PlayerEngineImpl implements PlayerEngine {
 					// i guess this mean we can play the song
 					Log.i(JamendoApplication.TAG, "Player [playing] "+mCurrentMediaPlayer.playlistEntry.getTrack().getName());
 					
+					final JamendoApplication app = JamendoApplication.getInstance();
+
 					// starting timer
                     mHandler.removeCallbacks(mUpdateTimeTask);
                     mHandler.postDelayed(mUpdateTimeTask, 1000);
                     
-                    // Mantain the settings of the equalizer for the new media
+                    // Maintain the settings of the equalizer for the new media
                     Equalizer newEqualizer = new Equalizer(0, mCurrentMediaPlayer.getAudioSessionId());
-                    Equalizer.Settings eqSettings = JamendoApplication.getInstance().getEqualizerSettigns();
-                    if (eqSettings != null) {
-                        newEqualizer.setProperties(eqSettings);
-					}
-                    
+                    short preset = app.getEqualizerPreset();
+                    // special case when the preset was chosen when there was no media stream running
+                    if (preset > -2) {
+                        newEqualizer.usePreset(preset);
+                        app.setEqualizerPreset((short) -2);
+                    } else {
+	                    Equalizer.Settings eqSettings = app.getEqualizerSettigns();
+	                    if (eqSettings != null) {
+	                        newEqualizer.setProperties(eqSettings);
+						}
+                    }
+                    // save settings for the next equalizer
+                    app.updateEqualizerSettings(newEqualizer.getProperties());
                     // Enable equalizer before media starts
                     JamendoApplication.getInstance().setMyEqualizer(newEqualizer);
                     JamendoApplication.getInstance().getMyEqualizer().setEnabled(true);

--- a/src/com/teleca/jamendo/media/PlayerEngineImpl.java
+++ b/src/com/teleca/jamendo/media/PlayerEngineImpl.java
@@ -214,13 +214,11 @@ public class PlayerEngineImpl implements PlayerEngine {
                     mHandler.removeCallbacks(mUpdateTimeTask);
                     mHandler.postDelayed(mUpdateTimeTask, 1000);
                     
-                    // Actual equalizer
-                    Equalizer equalizer = JamendoApplication.getInstance().getMyEqualizer();
-
                     // Mantain the settings of the equalizer for the new media
                     Equalizer newEqualizer = new Equalizer(0, mCurrentMediaPlayer.getAudioSessionId());
-                    if (equalizer != null) {
-                    	newEqualizer.setProperties(equalizer.getProperties());
+                    Equalizer.Settings eqSettings = JamendoApplication.getInstance().getEqualizerSettigns();
+                    if (eqSettings != null) {
+                        newEqualizer.setProperties(eqSettings);
 					}
                     
                     // Enable equalizer before media starts
@@ -266,7 +264,7 @@ public class PlayerEngineImpl implements PlayerEngine {
 	 */
 	private void cleanUp(){
 		// nice clean-up job
-		if(mCurrentMediaPlayer != null)
+		if(mCurrentMediaPlayer != null) {
 			try{
 				mCurrentMediaPlayer.stop();
 			} catch (IllegalStateException e){
@@ -275,6 +273,13 @@ public class PlayerEngineImpl implements PlayerEngine {
 				mCurrentMediaPlayer.release();
 				mCurrentMediaPlayer = null;
 			}
+			// reset equalizer - it cannot be reused that way on API level 14+
+			Equalizer eq = JamendoApplication.getInstance().getMyEqualizer();
+			if (eq != null) {
+				eq.release();
+				JamendoApplication.getInstance().setMyEqualizer(null);
+			}
+		}
 	}
 
 	private InternalMediaPlayer build(PlaylistEntry playlistEntry){


### PR DESCRIPTION
I think I have a solution for the Equalizer problem ([issue #24](https://github.com/telecapoland/jamendo-android/issues/24)).

The root cause was the fact that most probably on ICS+ versions Equalizer is bound to the lifetime of a MediaPlayer. As a result every time after MediaPlayer is released Equalizer needs to be released as well.

This caused some architectural changes - a global equalizer object can no longer be used (since it was valid only as long as the same song was playing). 

There were two special cases to be handled (when the global equalizer is unavailable):
- the song is stopped (no MediaPlayer object) and we want to manipulate the equalizer
- we open the equalizer during one song, it finishes and the next one is played - then we manipulate the equalizer
  Those cases needed to be covered by some kind of settings serialization and passing to the next Equalizer. Luckily, the Equalizer.Settings class have all what was needed for that purpose.

The global Equalizer object is used only when available (this is checked by the JamendoApplication.isEqualizerRunning method) to apply the settings in runtime. All other situations (no media playback) are covered using the Settings object instance passed to the newly created equalizer.

As a side effect I have implemented an Equalizer settings persistence mechanism to store settings between app launches.

Additionally I have found a typo in layout-mdpi/player.xml - pressing the Equalizer button was triggering 'Add to playlist' action.

I have added an additional permission (android.permission.MODIFY_AUDIO_SETTINGS) to the manifest. This was necessary to occasionally create a global Equalizer object to obtain some common settings (presets, number of bands and their level range) when the JamendoApplication.mEqualizer was not available.

I have verified this solution on Nexus S (JB), Sony Xperia P (ICS) and Samsung Galaxy Gio (GB). Seems to be working correctly.
